### PR TITLE
Modernize S3 deployment workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: setup-python
         name: Setup Python
@@ -44,7 +44,7 @@ jobs:
 
       - id: upload-release-candidate
         name: Upload release candidate
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-candidate
           path: ./docs/_build/html/
@@ -56,14 +56,14 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     steps:
       - name: Download release candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-candidate
           path: ./docs/
 
       - id: configure-aws
         name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.PALEWIRE_DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PALEWIRE_DOCS_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- Modernize the documentation S3 deployment workflow to match the current Palewire lesson-plan pattern.
- Update the GitHub Actions used for checkout, release-candidate artifact upload/download, and AWS credential configuration.
- Preserve the existing trigger, build command, S3 bucket/base path, and secret/variable names.

## Reference pattern
Standardized against the newer workflows in this repository collection, especially:
- `palewire/cuny-jour-73361-coding-the-news` `.github/workflows/deploy.yml`
- `palewire/first-llm-classifier` `.github/workflows/docs.yaml`
- `palewire/first-pmtiles-map` `.github/workflows/docs.yaml`

Conventions applied:
- Build once, upload a `release-candidate` artifact, then deploy from a separate `deploy` job.
- `actions/checkout@v6`
- `actions/upload-artifact@v7`
- `actions/download-artifact@v8`
- `aws-actions/configure-aws-credentials@v6`
- Keep `datadesk/delivery-deploy-action@v1` with existing deploy options.

## Validation
- `git diff --check`
- YAML parsed successfully with PyYAML
