### PR TITLE
Tidy Sphinx configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,9 +18,7 @@ html_sidebars = {
     ]
 }
 html_theme_options = {
-    "canonical_url": f"https://palewi.re/docs/first-web-scraper/",
-}
-html_theme_options = {
+    "canonical_url": "https://palewi.re/docs/first-web-scraper/",
     "nosidebar": True,
 }
 


### PR DESCRIPTION
## Summary
- Merge the duplicate `html_theme_options` blocks in `docs/conf.py`
- Preserve the existing `nosidebar` setting while restoring the canonical URL option that was being overwritten

## Validation
- `uv run --with sphinx==7.2.6 --with myst-parser==2.0.0 --with sphinx-palewire-theme==0.0.18 sphinx-build -b html ./docs /tmp/palewire_first-web-scraper_sphinx_tidy_check --keep-going`
- Confirmed generated HTML includes the canonical link for `https://palewi.re/docs/first-web-scraper/`

Note: strict `-W` validation still fails on pre-existing documentation warnings outside this config-only cleanup, including the missing `_templates/nav.html` include and MyST heading-level warnings.
